### PR TITLE
Adding trim to the display name

### DIFF
--- a/User.Api/Model/PersonalInformation.cs
+++ b/User.Api/Model/PersonalInformation.cs
@@ -17,7 +17,7 @@ namespace User.Api.Model
         {
             get
             {
-                return $"{Name} {Surname}";
+                return string.Join(' ', Name, Surname).Trim();
             }
         }
     }


### PR DESCRIPTION
Trimming `display_name` property.

Fix #8 